### PR TITLE
Move <footer> before </html>

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -13,8 +13,6 @@ const { title, description } = Astro.props;
 		<BaseHead title={title} description={description} />
 	</head>
 	<body>
-		<main>
-			<slot />
-		</main>
+		<slot />
 	</body>
 </html>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -10,19 +10,20 @@ import Layout from "@/layouts/Layout.astro";
 	title={"Toki Pona (Homepage)"}
 	description={"Toki Pona: the language with only 120 words."}
 >
-	<section style='grid-area: right;'>
-		<HomepageLeft />
-	</section>
-	<section style='grid-area: left;'>
-		<HomepageRight />
-	</section>
+	<main>
+		<section style='grid-area: right;'>
+			<HomepageLeft />
+		</section>
+		<section style='grid-area: left;'>
+			<HomepageRight />
+		</section>
+	</main>
+	<footer>
+		Made by and for the Toki Pona community.<br />
+		Contact us at: <a href='mailto:kulupu@tokipona.net'>kulupu@tokipona.net</a
+		>.<br />
+		Source code is available on <a
+			href='https://github.com/pona-la/toki-pona-homepage'>GitHub</a
+		>.
+	</footer>
 </Layout>
-
-<footer>
-	Made by and for the Toki Pona community.<br />
-	Contact us at: <a href='mailto:kulupu@tokipona.net'>kulupu@tokipona.net</a
-	>.<br />
-	Source code is available on <a
-		href='https://github.com/pona-la/toki-pona-homepage'>GitHub</a
-	>.
-</footer>


### PR DESCRIPTION
The `<footer>` tag currently gets generated *after* the ending `</html>`. To fix this, we should either include the footer in Layout.astro, or make Layout.astro accept content straight into `<html>` rather than assuming it should go in `<main>`. I picked the second, but the first may make more sense if we expect this footer to show up on most pages.

This PR has no real functional impact on the site; the footer looks exactly the same.